### PR TITLE
Added new test runner target and a few other possible improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ include(FetchContent)
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG        release-1.12.1
+  GIT_TAG release-1.12.1
 )
 FetchContent_MakeAvailable(googletest)
 add_library(GTest::GTest INTERFACE IMPORTED)
@@ -25,10 +25,12 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 -Wall -fprofile-arcs -ftest-coverage 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 -Wall -fprofile-arcs -ftest-coverage -fprofile-generate -Wno-unused-function")
 
 include_directories(
+  src
 )
 
 add_executable(
   test_suite
+  src/RockPaperScissors.cpp
   test/RockPaperScissors_test.cpp
 )
 
@@ -38,21 +40,25 @@ target_link_libraries(
 )
 
 add_custom_target(coverage
-    COMMAND find . -name "*.gcda" -delete
-    COMMAND ./test_suite
-    COMMAND gcovr -r ${PRODUCTION_CODE} .
-    DEPENDS test_suite)
+  COMMAND find . -name "*.gcda" -delete
+  COMMAND ./test_suite
+  COMMAND gcovr -r ${PRODUCTION_CODE} .
+  DEPENDS test_suite)
 
 add_custom_target(coverage-report
-    COMMAND find . -name "*.gcda" -delete
-    COMMAND ./test_suite
-    COMMAND mkdir -p coverage
-    COMMAND gcovr -b -d -r ../../src . --html-details coverage/report.html
-    DEPENDS test_suite)
+  COMMAND find . -name "*.gcda" -delete
+  COMMAND ./test_suite
+  COMMAND mkdir -p coverage
+  COMMAND gcovr -b -d -r ../../src . --html-details coverage/report.html
+  DEPENDS test_suite)
 
 file(GLOB_RECURSE complexity_list "../src/*.c" "../src/*.cpp" "../src/*.cc" "../src/*.h")
 
 add_custom_target(complexity
-    COMMAND pmccabe ${complexity_list} | sort -nr | head -100)
-    
+  COMMAND pmccabe ${complexity_list} | sort -nr | head -100)
+
+add_custom_target(run-tests DEPENDS test_suite
+  COMMAND ./test_suite
+)
+
 gtest_discover_tests(test_suite)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This codespace environment should be setup properly. This includes the ability t
 ## Build/Run
 To build and run:
 ```
- cmake -S . -B build && cmake --build build --target test_suite test
+ cmake -S . -B build && cmake --build build --target run-tests
 ```
 
 ## Example Answers

--- a/src/RockPaperScissors.h
+++ b/src/RockPaperScissors.h
@@ -1,0 +1,4 @@
+#ifndef ROCKPAPERSCISSORS_H
+#define ROCKPAPERSCISSORS_H
+
+#endif


### PR DESCRIPTION
I had a couple thoughts for making this a little more ergonomic:

- [x] Added blank files so people know where their work is expected to go
- [x] Added `run-tests` command to build and run the verbose form of the tests, I think this or something like it should be standard moving forward
- [x] Updated README to refer to `run-tests`
- [x] Added those files to CMakeLists.tx so people don't need to modify (IMO this might be too much information for a first lesson)
- [x] Formatter picked up some things in CMakeLists